### PR TITLE
Track plugin load time and format `oxide.reload` output

### DIFF
--- a/src/Commands.cs
+++ b/src/Commands.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using uMod.Libraries;
 using uMod.Libraries.Universal;
 using uMod.Plugins;
+using uMod.Utilities;
 
 namespace uMod
 {
@@ -312,19 +314,22 @@ namespace uMod
                 return;
             }
 
-            string output = $"Listing {loadedPlugins.Length + unloadedPluginErrors.Count} plugins:"; // TODO: Localization
+            FacePunchTextTable table = new FacePunchTextTable();
+            table.AppendLine($"Listing {loadedPlugins.Length + unloadedPluginErrors.Count} loaded plugins:"); // TODO: Localization
             int number = 1;
+            table.AddColumns("Index", "Plugin", "Version", "Author", "Hook Execution", "Time Loaded", "File Name / Error");
             foreach (Plugin plugin in loadedPlugins.Where(p => p.Filename != null))
             {
-                output += $"\n  {number++:00} \"{plugin.Title}\" ({plugin.Version}) by {plugin.Author} ({plugin.TotalHookTime:0.00}s) - {plugin.Filename.Basename()}";
+                var timeLoaded = DateTime.Now.Subtract(plugin.TimeLoaded);
+                table.AddRow(number++.ToString("00"), plugin.Title.ToString(), plugin.Version.ToString(), plugin.Author, $"{plugin.TotalHookTime:0.00}s", $"{(int)timeLoaded.TotalHours:00}:{timeLoaded.Minutes:00}", plugin.Filename.Basename());
             }
 
             foreach (string pluginName in unloadedPluginErrors.Keys)
             {
-                output += $"\n  {number++:00} {pluginName} - {unloadedPluginErrors[pluginName]}";
+                table.AppendLine($"{pluginName} - {unloadedPluginErrors[pluginName]}");
             }
 
-            player.Reply(output);
+            player.Reply(table.ToString());
         }
 
         #endregion Plugins Command

--- a/src/Plugins/Plugin.cs
+++ b/src/Plugins/Plugin.cs
@@ -131,6 +131,11 @@ namespace uMod.Plugins
         public bool IsLoaded { get; internal set; }
 
         /// <summary>
+        /// Store the time the plugin was loaded so we can calculate average hook execution time
+        /// </summary>
+        public DateTime TimeLoaded { get; internal set; }
+
+        /// <summary>
         /// Gets or sets the total hook time
         /// </summary>
         /// <value>The total hook time.</value>

--- a/src/Utilities/FacepunchTextTable.cs
+++ b/src/Utilities/FacepunchTextTable.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace uMod.Utilities
+{
+    public class FacePunchTextTable
+    {
+        private class Row
+        {
+            public string[] values;
+
+            public Row(string[] values)
+            {
+                this.values = values;
+            }
+        }
+
+        private class Column
+        {
+            public string title;
+
+            public int width;
+
+            public Column(string title)
+            {
+                this.title = title;
+                width = title.Length;
+            }
+        }
+
+        private List<Row> rows = new List<Row>();
+
+        private List<Column> columns = new List<Column>();
+
+        private StringBuilder builder = new StringBuilder();
+
+        private string text = string.Empty;
+
+        private bool dirty;
+
+        public void Clear()
+        {
+            rows.Clear();
+            columns.Clear();
+            dirty = true;
+        }
+
+        public void AddColumns(params string[] values)
+        {
+            for (int i = 0; i < values.Length; i++)
+            {
+                columns.Add(new Column(values[i]));
+            }
+            dirty = true;
+        }
+
+        public void AddColumn(string title)
+        {
+            columns.Add(new Column(title));
+            dirty = true;
+        }
+
+        public void AddRow(params string[] values)
+        {
+            int num = Math.Min(columns.Count, values.Length);
+            for (int i = 0; i < num; i++)
+            {
+                columns[i].width = Math.Max(columns[i].width, values[i].Length);
+            }
+            rows.Add(new Row(values));
+            dirty = true;
+        }
+
+        public void AppendLine(string line)
+        {
+            builder.AppendLine(line);
+            dirty = true;
+        }
+
+        public override string ToString()
+        {
+            if (dirty)
+            {
+                //net 3.5 workaround instead of StringBuilder.Clear()
+                builder.Length = 0;
+                for (int i = 0; i < columns.Count; i++)
+                {
+                    builder.Append(columns[i].title.PadRight(columns[i].width + 1));
+                }
+                builder.AppendLine();
+                for (int j = 0; j < rows.Count; j++)
+                {
+                    Row row = rows[j];
+                    int num = Math.Min(columns.Count, row.values.Length);
+                    for (int k = 0; k < num; k++)
+                    {
+                        builder.Append(row.values[k].PadRight(columns[k].width + 1));
+                    }
+                    builder.AppendLine();
+                }
+                text = builder.ToString();
+                dirty = false;
+            }
+            return text;
+        }
+    }
+}

--- a/src/uMod.cs
+++ b/src/uMod.cs
@@ -526,6 +526,7 @@ namespace uMod
                 }
 
                 plugin.IsLoaded = true;
+                plugin.TimeLoaded = DateTime.Now;
                 if (!plugin.IsCorePlugin)
                 {
                     LogInfo($"Loaded plugin {plugin.Title} v{plugin.Version} by {plugin.Author}"); // TODO: Localization


### PR DESCRIPTION
Added a class from Rust.Global renamed as **FacePunchTextTable** which allows you to format text tables in console easily.

Added a field to Plugin called **TimeLoaded** which will keep track of the time a plugin is loaded.

Formatted the output from _oxide.plugins_ and included how long the plugin has been loaded to make it easier to read and easier to compare hook execution times.
