### PR TITLE
fix WebRequest.cs

### DIFF
--- a/src/Libraries/WebRequests.cs
+++ b/src/Libraries/WebRequests.cs
@@ -175,8 +175,8 @@ namespace Oxide.Core.Libraries
                                 OnComplete();
                                 return;
                             }
-                            WaitForResponse();
                         }, null);
+                        WaitForResponse();
                     }
                     else
                     {


### PR DESCRIPTION
Depending on the timing of the request and response, the callback to Enqueue() is sometimes never called. WaitForResponse() should be called after BeginGetRequestStream(). This fixes the missed callback.